### PR TITLE
show legend across two rows

### DIFF
--- a/R/visPed.R
+++ b/R/visPed.R
@@ -674,11 +674,12 @@ visEngine <- function(x, annot, feature.name = NULL,
     legend = substring(dimnames(x$affected)[[2]], 6),
     border = NA,
     col = colmat,
-    horiz = TRUE,
+    # horiz = TRUE,
     cex = 0.8,
     bty = "n",
     # pch = c(rep(".", length(colmat)), "[C]"),
-    fill = colmat
+    fill = colmat,
+    ncol = 9
   )
 
   if (!is.null(feature.name)) {


### PR DESCRIPTION
Shows 18 cancers in legend in two rows (or 9 columns).

Closes #5 